### PR TITLE
Add debug_name macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,11 @@ chance that it will suit your needs.
 - New handy macros (mostly for development purposes):
   
   ```rust
-  use stdext::{compile_warning, function_name};
+  use stdext::{compile_warning, debug_name, function_name};
 
   fn sample_function() {
     println!("This function is called {}", function_name!());
+    println!("You can also found it here:", debug_name!());
 
     compile_warning!("This function must do something else...");
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,9 +58,11 @@
 //!
 //! - [`compile_warning`] for spawning a user-defined compilation warnings.
 //! - [`function_name`] for getting an enclosing function name.
+//! - [`debug_name`] for getting a helpful string for debug.
 //!
 //! [`compile_warning`]: ./macro.compile_warning.html
 //! [`function_name`]: ./macro.function_name.html
+//! [`debug_name`]: ./macro.debug_name.html
 //!
 //! ## Highlights
 //!
@@ -115,10 +117,11 @@
 //! - New handy macros (mostly for development purposes):
 //!   
 //!   ```rust
-//!   use stdext::{compile_warning, function_name};
+//!   use stdext::{compile_warning, debug_name, function_name};
 //!
 //!   fn sample_function() {
 //!     println!("This function is called {}", function_name!());
+//!     println!("You can also found it here: {}", debug_name!());
 //!
 //!     compile_warning!("This function must do something else...");
 //!   }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -73,6 +73,41 @@ macro_rules! function_name {
     }};
 }
 
+/// This macro returns the name of the enclosing function, line number and also filename.
+/// As the internal implementation is based on the [`std::any::type_name`], this macro derives
+/// all the limitations of this function.
+///
+/// ## Examples
+///
+/// ```rust
+/// mod bar {
+///     pub fn sample_function() {
+///         use stdext::debug_name;
+///         assert!(debug_name!().starts_with("src/macros.rs:8"));
+///         assert!(debug_name!().ends_with("bar::sample_function"));
+///     }
+/// }
+///
+/// bar::sample_function();
+/// ```
+///
+/// [`std::any::type_name`]: https://doc.rust-lang.org/std/any/fn.type_name.html
+#[macro_export]
+macro_rules! debug_name {
+    () => {{
+        fn f() {}
+        fn type_name_of<T>(_: T) -> &'static str {
+            std::any::type_name::<T>()
+        }
+        let name = type_name_of(f);
+        // `3` is the length of the `::f`.
+        let trimmed_name = &name[..name.len() - 3];
+        let file = file!();
+        let line = line!();
+        format!("{file}:{line} at {trimmed_name}")
+    }};
+}
+
 /// Attempts to get variant from the enum variable.
 ///
 /// ## Examples


### PR DESCRIPTION
This macro helps developers to have good debug information to show in code and help them find it via a modern IDE