### PR TITLE
Add freestanding `default()`

### DIFF
--- a/src/default.rs
+++ b/src/default.rs
@@ -1,0 +1,31 @@
+//! Freestanding version of `std::default::Default::default()`.
+
+/// Freestanding version of `std::default::Default::default()`.
+///
+/// Used to be available under `#![feature(default_free_fn)]`,
+/// removed in https://github.com/rust-lang/rust/pull/113469.
+///
+/// # Examples
+///
+/// ```
+/// use stdext::prelude::*;
+///
+/// #[derive(Default, PartialEq, Eq, Debug)]
+/// struct StructWithLongName {
+///     a: u32,
+///     b: u32,
+/// }
+///
+/// let s = StructWithLongName {
+///     a: 12,
+///     ..default() // Normally you have to do
+///                 // `Default::default()`,
+///                 // `<_>::default()` or
+///                 // `StructWithLongName::default()`
+/// };
+///
+/// assert_eq!(s, StructWithLongName { a: 12, ..<_>::default() });
+/// ```
+pub fn default<T: Default>() -> T {
+    T::default()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,7 @@
 pub mod duration;
 #[macro_use]
 pub mod macros;
+pub mod default;
 pub mod num;
 pub mod option;
 pub mod result;
@@ -142,6 +143,7 @@ pub mod vec;
 /// A "prelude" module which re-exports all the extension traits for the simple library usage.
 pub mod prelude {
     pub use crate::{
+        default::*,
         duration::*,
         num::{float_convert::*, integer::*},
         option::*,


### PR DESCRIPTION
The freestanding `default()` function, formerly available under `#![feature(default_free_fn)]`, was removed in https://github.com/rust-lang/rust/pull/113469. I've seen it used in some projects' docs (namely [bevy](https://docs.rs/bevy/latest/bevy/prelude/fn.default.html)), and I think it's at the same time less unwieldy than `StructWithReallyLongName::default()`, less ugly than `<_>::default()`, and less stuttery than `Default::default()`.